### PR TITLE
Add some python guidelines

### DIFF
--- a/Python.md
+++ b/Python.md
@@ -1,8 +1,4 @@
-# Python programming language
-
-The general suggestion of writing tests applies here. Try to test all of the
-code that is being written and don't delay that for later (it will not get
-easier).
+# Python programming guidelines
 
 ## Code style
 
@@ -45,6 +41,7 @@ An example of a docstring for a regular method:
 ```python
 def frob(foo, bar=None):
     """Frob a foo, with an optional bar operation.
+
     An optional, more detailed description of this function if needed.
 
     Args:

--- a/Python.md
+++ b/Python.md
@@ -29,13 +29,41 @@ The general idea is to make the code within a project consistent and easy to int
 
 ### Docstrings
 
-Include docstrings in functions. This should say *what* the function does, its *inputs*,
+Documentation helps us understand what a function does without having to read its implementation.
+
+Include docstrings in functions. This should say *what* the function does, and its *inputs*
 and *outputs* or possible *failure states* (exceptions).
+
+If a function is very short (say, less than 5 lines) and its name documents what it does,
+a docstring may not be necessary.
 
 Unless otherwise stated, we use "Google-style" docstrings:
 https://google.github.io/styleguide/pyguide.html?showone=Comments#Comments.
 
-For flask application docstrings for views are turned into API Documentation
+An example of a docstring for a regular method:
+
+```python
+def frob(foo, bar=None):
+    """Frob a foo, with an optional bar operation.
+    An optional, more detailed description of this function if needed.
+
+    Args:
+        foo: The foo to be frobbed.
+        bar: If set, a callback to a bar operation to be applied after
+             the foo is frobbed.
+
+    Returns:
+        The new foo, after frobbing and baring.
+
+    Raises:
+        ValueError if the foo cannot be frobbed.
+```
+
+Take note that sentences always start with a capital letter and end with a .
+
+
+For flask application we use Sphinx with [autohttp.flask](https://pythonhosted.org/sphinxcontrib-httpdomain/)
+to generate documentation for webserver views.
 (See an example for AcousticBrainz at http://acousticbrainz.readthedocs.io/)
 
 View docstrings should be formatted to include query format and an example of the response:
@@ -55,18 +83,6 @@ View docstrings should be formatted to include query format and an example of th
   be >= 0
 :resheader Content-Type: *application/json*
 """
-```
-
-An example of a docstring for a regular method
-```python
-def frob(foo, bar=None):
-    """Frob a foo, with an optional bar operation
-       Args:
-           foo: the foo to be frobbed
-           bar: if set, a callback to a bar operation to be applied after
-                the foo is frobbed
-       Returns:
-           The new foo, after frobbing and baring
 ```
 
 

--- a/Python.md
+++ b/Python.md
@@ -108,8 +108,6 @@ result = connection.execute(query, {'musicbrainz_usernames': tuple(usernames)})
 It is preferred to assign the query to a separate variable and not include it inside the
 `execute` call.
 
-TODO: Projects which don't use sqlalchemy
-
 ### Tests
 
 You should write tests for all new code that you write. If you update code, make sure that

--- a/Python.md
+++ b/Python.md
@@ -6,6 +6,11 @@ easier).
 
 ## Code style
 
+Note: While this is section describes an ideal style, we know that parts of MetaBrainz
+projects do not follow these guidelines exactly. We are pragmatic in our application of the
+guidelines and try our best to follow them, but there will be deviations. When in doubt, follow
+the guidelines rather than copying existing code.
+
 As most of the other projects written in Python, we use [PEP 8]
 (https://www.python.org/dev/peps/pep-0008/).  We change some of the recomendations:
 
@@ -15,23 +20,63 @@ As most of the other projects written in Python, we use [PEP 8]
 (https://www.youtube.com/watch?v=wf-BqAjZb8M)" by Raymond Hettinger at PyCon 2015,
 which talks about the famous P versus NP problem.*
 
+If the project has a `pylintrc` file, you can use pylint to check for potential style violations:
+
+    pylint --rcfile=pylintrc
+
 The general idea is to make the code within a project consistent and easy to interpret (for humans).
+
 
 ### Docstrings
 
-Unless the function is easy to understand quickly, it should have a docstring
-describing what it does, how it does it, what the arguments are, and what the
-expected output is.
+Include docstrings in functions. This should say *what* the function does, its *inputs*,
+and *outputs* or possible *failure states* (exceptions).
 
-Most of our Python projects use "Google-style" docstrings:
+Unless otherwise stated, we use "Google-style" docstrings:
 https://google.github.io/styleguide/pyguide.html?showone=Comments#Comments.
+
+For flask application docstrings for views are turned into API Documentation
+(See an example for AcousticBrainz at http://acousticbrainz.readthedocs.io/)
+
+View docstrings should be formatted to include query format and an example of the response:
+
+```python
+"""Get low-level data for many recordings at once.
+
+**Example response**:
+
+.. sourcecode:: json
+
+   {"mbid1": {"some": "json"}}
+
+:query recording_ids: *Required.* A list of recording MBIDs to retrieve
+
+  Takes the form `mbid[:offset];mbid[:offset]`. Offsets are optional, and should
+  be >= 0
+:resheader Content-Type: *application/json*
+"""
+```
+
+An example of a docstring for a regular method
+```python
+def frob(foo, bar=None):
+    """Frob a foo, with an optional bar operation
+       Args:
+           foo: the foo to be frobbed
+           bar: if set, a callback to a bar operation to be applied after
+                the foo is frobbed
+       Returns:
+           The new foo, after frobbing and baring
+```
+
 
 ### SQL
 
-TODO: How to write and format SQL queries (with and without using SQLAlchemy).
+For projects which use sqlalchemy-core, we use `sqlalchemy.text` to write prepared statements. SQL keywords
+should be in upper-case and right aligned. For example:
 
 ```python
-result = connection.execute(sqlalchemy.text("""
+query = sqlalchemy.text("""
     SELECT id,
            display_name,
            email,
@@ -40,7 +85,37 @@ result = connection.execute(sqlalchemy.text("""
            show_gravatar
       FROM "user"
      WHERE musicbrainz_id IN :musicbrainz_usernames
-"""), {
-    'musicbrainz_usernames': tuple(usernames),
-})
+""")
+result = connection.execute(query, {'musicbrainz_usernames': tuple(usernames)})
 ```
+
+It is preferred to assign the query to a separate variable and not include it inside the
+`execute` call.
+
+TODO: Projects which don't use sqlalchemy
+
+### Tests
+
+You should write tests for all new methods that you write. If you update a method, make sure that
+tests for that method still pass, and write/remove tests as necessary for the change in functionality.
+
+Tests for a module (`package/module.py`) go in a `test` subdirectory - `package/test/test_module.py`
+
+Database tests (for modules in `db`) can use the database. Inherit from `db.testing.DatabaseTestCase`
+to automatically reset the database at the end of each testcase.
+
+Try and isolate tests as much as possible. If you have a utility function which transforms or validates
+and input, you can test this in isolation.
+
+Webserver tests don't need to write data to the database. Instead, you can use a mock to verify
+that the call to the database was made:
+
+```python
+@mock.patch("db.data.load_high_level")
+def test_hl_numerical_offset(self, hl):
+    hl.return_value = {}
+    resp = self.client.get("/api/v1/%s/high-level?n=3" % self.uuid)
+    self.assertEqual(200, resp.status_code)
+    hl.assert_called_with(self.uuid, 3)
+```
+

--- a/Python.md
+++ b/Python.md
@@ -112,18 +112,19 @@ TODO: Projects which don't use sqlalchemy
 
 ### Tests
 
-You should write tests for all new methods that you write. If you update a method, make sure that
-tests for that method still pass, and write/remove tests as necessary for the change in functionality.
+You should write tests for all new code that you write. If you update code, make sure that
+tests still pass, and write/remove tests as necessary for any change in functionality.
 
-Tests for a module (`package/module.py`) go in a `test` subdirectory - `package/test/test_module.py`
+Tests for a module (`package/module.py`) go in a `test` package - `package/test/test_module.py`
 
-Database tests (for modules in `db`) can use the database. Inherit from `db.testing.DatabaseTestCase`
-to automatically reset the database at the end of each testcase.
+Database tests should automatically clear the database and recreate the database after each test
+to ensure that one test doesn't affect the behaviour of another. Each project should have a subclass
+of `TestCase` which you can inherit from to do this.
 
 Try and isolate tests as much as possible. If you have a utility function which transforms or validates
-and input, you can test this in isolation.
+an input, you can test this in isolation.
 
-Webserver tests don't need to write data to the database. Instead, you can use a mock to verify
+Web server tests don't need to write data to the database. Instead, you can use a mock to verify
 that the call to the database was made:
 
 ```python


### PR DESCRIPTION
Based on @gentlecat's comment at https://github.com/metabrainz/acousticbrainz-server/pull/224#issuecomment-283349041 - 
moving general metabrainz guidelines to this repository. 

As I mentioned in the previous PR, my preference would be to merge this quickly and iterate on the content in place (especially given that it's SoC season)