### PR TITLE
Update GitHub & Jira guidelines with the new GitHub Bot’s automation rule in Jira

### DIFF
--- a/GitHub.md
+++ b/GitHub.md
@@ -7,7 +7,8 @@ We follow the "typical" GitHub workflow when contributing changes:
 1. [Fork](https://help.github.com/articles/fork-a-repo/) a repository into your account.
 2. Create a new branch and give it a meaningful name. For example, if you are going to fix issue MBS-4635, branch can be
    called `mbs-4635` or `replace-image`.
-3. Make your changes and commit them with a [good description](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html). *You don't need to provide a lot
+3. Make your changes and commit them with a [good description](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
+   ([more details](https://chris.beams.io/posts/git-commit/)). *You don't need to provide a lot
    of details, but make sure that people who look at the commit history afterwards can understand what you were changing
    and why.*
 4. [Create](https://help.github.com/articles/creating-a-pull-request/) a new pull request on GitHub. Make sure that

--- a/GitHub.md
+++ b/GitHub.md
@@ -15,6 +15,8 @@ We follow the "typical" GitHub workflow when contributing changes:
    title of your pull request is descriptive. If you are fixing an issue that exists in our bug tracker reference it
    like this: `MBS-4635: Allow replacing images`. **Not** `[MBS-4635] - Allow replacing images` or `Allow replacing images
    (MBS-4635)` or `MBS-4635`.
+   If you are fixing several issues at once, reference it like this: `MBS-9477, MBS-10568, MBS-10569: DiscID tab improvements`.
+   In the rare case you are partially fixing an issue, reference it like this: `MBS-10365 (III): Convert EventList to react-table`.
 5. :shipit:
 
 ## Status checks and testing

--- a/Jira.md
+++ b/Jira.md
@@ -4,7 +4,8 @@ MetaBrainz uses Jira to track bugs and tasks. It is hosted at https://tickets.me
 
 Each main MetaBrainz project has [its own project in Jira](https://tickets.metabrainz.org/secure/BrowseProjects.jspa).
 
-This document describes
+This document describes how to work on reported tickets a.k.a. issues.
+
 For information about how to report an issue in a MetaBrainz project,
 [see our wiki](https://wiki.musicbrainz.org/How_to_Report_an_Issue).
 

--- a/Jira.md
+++ b/Jira.md
@@ -28,10 +28,15 @@ You do not need to contact them yourself to make sure that they recieved your co
 When you have assigned a ticket to yourself, set its status to "In Progress" by clicking
 `Start Progress`. This shows others that you are actively working on a task.
 
-When you finish the task, open a Pull Request on the relavent project. See [GitHub.md] with
-additional information about how to name and submit a Pull Request. In Jira, click `Resolve Issue`
-to mark that a review has been submitted, and paste a link to the GitHub Pull Request URL as
-a comment.
+When you finish the task, open a _Pull Request_ on the relevant project.
+You may instead want to open it as a _draft_ if it cannot be merged yet,
+for example when it depends on another Pull Request.
 
-Once a pull request has been reviewed and merged by one of the project maintainers, it
-can be closed and marked as "Fixed".
+If you correctly followed [how to name and submit a Pull Request](GitHub.md),
+_GitHub Bot_ automatically marks in Jira that a review has been submitted,
+with a link to the GitHub Pull Request in a comment.
+Once a pull request has been reviewed and merged by one of the project maintainers,
+it automatically marks in Jira that it has been merged into the development branch.
+
+It is up to the project maintainers to mark tickets in beta testing or to close
+these as “Fixed” when the corresponding deployment steps have been completed.


### PR DESCRIPTION
* Document the recently implemented automatic transitioning of tickets by GitHub Bot in Jira.
* Expand a bit on details about submitting changes. These are taken from [`CONTRIBUTING.md`](https://github.com/metabrainz/musicbrainz-server/blob/3edc2d4bf5caf3712a06fb30c7297a24249c738c/CONTRIBUTING.md) in pull request https://github.com/metabrainz/musicbrainz-server/pull/1345 on @alastair’s suggestion.