### PR TITLE
Document using RabbitMQ for main contributors

### DIFF
--- a/services/README.md
+++ b/services/README.md
@@ -1,0 +1,51 @@
+# Guidelines for using self-hosted services in MetaBrainz projects
+
+This is a set of guidelines for the main contributors of MetaBrainz
+projects to keep their use of self-hosted services maintainable.
+
+This document mentions general guidelines only about **documentation
+requirements** for a project when using a self-hosted service so
+that system adminstrators can actually understand what to do or to
+avoid without having to read the code to understand an emergency
+situation or to necessarily rely on the code authors to take action.
+
+It is completed by the service-specific guidelines in this directory
+which rather focus on **implementation requirements**.
+
+See also the private system administration wiki for details about how
+these self-hosted services are hosted in the MetaBrainz infrastructure.
+
+The below lists are indicative of what should likely be documented.
+Those are not exhaustive.
+
+## Requirements to be documented
+
+- Tolerance to connectivity issues:
+  What are the consequences of connectivity issues for the project?
+- Maintenance mode:
+  Is there a maintenance mode that can be set for maintenance of the
+  self-hosted service the project depends on?
+- Data importance:
+  How important is the data conveyed through the self-hosted service?
+  Can it be rebuilt if missing and at which cost?
+- Data persistence:
+  Does the project require the self-hosted service to hold any data
+  and to have backup?
+
+## Procedures to be documented
+
+- Start service
+- Reload service configuration
+- Stop service
+- Restart service
+- Move service
+- Remove service
+
+## Questions that can be answered for each procedure
+
+- Does it risk any data loss? (permissible or not)
+- Does it require before/during/after:
+  * Announcement of a downtime or a degradation of service to users?
+  * Firewall rules?
+  * Setup steps?
+  * Data dump?

--- a/services/RabbitMQ.md
+++ b/services/RabbitMQ.md
@@ -16,3 +16,12 @@ In the event the RabbitMQ service is not accessible for some reason, it would pr
 If messages should not be prevented to be queued:
 * [ ] Document which data might be missing
 * [ ] Provide a plan to produce those messages later on or to deal without those
+
+
+## Examples
+
+* (No project currently follows these guidelines.)
+
+Look for [not closed tickets](https://tickets.metabrainz.org/issues/?jql=labels+=+rabbitmq-service-guidelines+AND+status+!=+Closed),
+with `rabbitmq-service-guidelines` label, and create missing ones
+for projects which are using RabbitMQ without following these guidelines.

--- a/services/RabbitMQ.md
+++ b/services/RabbitMQ.md
@@ -6,7 +6,12 @@ Any deviation from those should be documented.
 
 * [ ] Report connectivity issues through Docker logs and critical connectivity issues through Sentry too.
 * [ ] Separate settings for consumer and producer; it allows to smoothly switch to another RabbitMQ instance using shovels.
+  And to help with debugging, read the following parameters (not limited to) from settings:
+  * [ ] Acknowledgement mode (manual or automatic)
+  * [ ] Heartbeat timeout (if different from server’s default)
+  * [ ] Message protocol (AMQP 0-8, AMQP 0-9-1, AMQP 1.0, MQTT...)
 * [ ] Check for queues declaration before accessing those from both consumer and producer; it prevents getting stuck after switching to a new instance.
+* [ ] Name each connection with project and role so those can be individually identified in the RabbitMQ admin console.
 
 If queued messages should not be lost:
 * [ ] Document which data might be missing
@@ -16,7 +21,6 @@ In the event the RabbitMQ service is not accessible for some reason, it would pr
 If messages should not be prevented to be queued:
 * [ ] Document which data might be missing
 * [ ] Provide a plan to produce those messages later on or to deal without those
-
 
 ## Examples
 

--- a/services/RabbitMQ.md
+++ b/services/RabbitMQ.md
@@ -1,0 +1,18 @@
+# Guidelines for using RabbitMQ in MetaBrainz projects
+
+Additionally to the [general guidelines for using services](README.md),
+here is a list of implementation requirements when using RabbitMQ.
+Any deviation from those should be documented.
+
+* [ ] Report connectivity issues through Docker logs and critical connectivity issues through Sentry too.
+* [ ] Separate settings for consumer and producer; it allows to smoothly switch to another RabbitMQ instance using shovels.
+* [ ] Check for queues declaration before accessing those from both consumer and producer; it prevents getting stuck after switching to a new instance.
+
+If queued messages should not be lost:
+* [ ] Document which data might be missing
+* [ ] Provide a command to pull/push queued messages to file
+
+In the event the RabbitMQ service is not accessible for some reason, it would prevent producers to queue new messages.
+If messages should not be prevented to be queued:
+* [ ] Document which data might be missing
+* [ ] Provide a plan to produce those messages later on or to deal without those


### PR DESCRIPTION
It provides guidelines on documenting and implementing the use of self-hosted RabbitMQ by MetaBrainz projects.
The goal is to make projects easier to deploy and to maintain, even by system admins.