### PR TITLE
Add LB documentation to examples for using RabbitMQ

### DIFF
--- a/services/RabbitMQ.md
+++ b/services/RabbitMQ.md
@@ -24,6 +24,9 @@ If messages should not be prevented to be queued:
 
 ## Examples
 
+* Documentation page “[LB > Maintainer Documentation > RabbitMQ](https://listenbrainz.readthedocs.io/en/latest/maintainers/rabbitmq.html)”
+  (still in development branch) <!-- TODO: replace /latest/ with /stable/ on release -->
+
 * Documentation page “[SIR > Service maintenance > RabbitMQ](https://sir.readthedocs.io/en/latest/service/index.html#rabbitmq-1)”
   (still in development branch) <!-- TODO: replace /latest/ with /stable/ on release -->
 

--- a/services/RabbitMQ.md
+++ b/services/RabbitMQ.md
@@ -25,10 +25,10 @@ If messages should not be prevented to be queued:
 ## Examples
 
 * Documentation page “[LB > Maintainer Documentation > RabbitMQ](https://listenbrainz.readthedocs.io/en/latest/maintainers/rabbitmq.html)”
-  (still in development branch) <!-- TODO: replace /latest/ with /stable/ on release -->
+  (still in development branch but already applicable to the release in production) <!-- TODO: replace /latest/ with /stable/ on release -->
 
 * Documentation page “[SIR > Service maintenance > RabbitMQ](https://sir.readthedocs.io/en/latest/service/index.html#rabbitmq-1)”
-  (still in development branch) <!-- TODO: replace /latest/ with /stable/ on release -->
+  (still in development branch but already applicable to the release in production) <!-- TODO: replace /latest/ with /stable/ on release -->
 
 Look for [not closed tickets](https://tickets.metabrainz.org/issues/?jql=labels+=+rabbitmq-service-guidelines+AND+status+!=+Closed),
 with `rabbitmq-service-guidelines` label, and create missing ones


### PR DESCRIPTION
Also clarify that even though linking to the `latest` documentation (in development), it already applies to the production.