### PR TITLE
Add AI use policy to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ you want to know more about the development process. More info about interesting
 ways we communicate with each other is available at https://wiki.musicbrainz.org/Communication.
 
 ## AI use policy
-We don't allow blindly using AI tools in code contributions or communications, and discourage it in most cases.
+We don't allow blindly using AI tools in code contributions or communications, and discourage it in most cases.\
+If you do use LLMs as part of your workflow, **you must explicitly disclose it**.
 
-If you do use LLMs as part of your workflow, you must explicitly disclose it.
-Do not submit a PR you haven't personally tested; inability to explain your code is grounds for immediate rejection of the PR. 
+Do not submit a PR you haven't personally tested; inability to explain your code is grounds for immediate rejection of the PR.\
 We want to see *you* (not an LLM) show understanding of the issue and do all the problem solving.
 
 This is the core of our work as developers. Open-source prioritizes community, critical thinking and robust and long-lasting code over productivity and speed.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,13 @@ Our developers use IRC for communication. You can join us in the
 [Libera.Chat network](https://libera.chat/). Feel free to come and say "Hi!" if
 you want to know more about the development process. More info about interesting
 ways we communicate with each other is available at https://wiki.musicbrainz.org/Communication.
+
+## AI use policy
+We discourage the use of AI tools in communications and code contributions.
+
+Do not submit an AI-generated PR you haven't **personally understood, tested and reviewed**, as this wastes maintainers' time.<br/>
+Undisclosed use of AI or Large Language Models, or inability to explain AI-generated contributions, will lead to your PR being **closed without further review**.
+
+If you use LLMs as part of your workflow (with explicit disclosure), **understanding the issue** and any **problem solving** should be done **by you**.
+
+This is the core of our work as developers. The job market and financially motivated projects may disagree, but this wonderful little open-source bubble has a humanistic philosophy, and prioritizes **community**, **critical thinking** and **robust and long-lasting code** over productivity and speed.

--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ you want to know more about the development process. More info about interesting
 ways we communicate with each other is available at https://wiki.musicbrainz.org/Communication.
 
 ## AI use policy
-We discourage the use of AI tools in communications and code contributions.
+We discourage blindly using AI tools in communications or code contributions.
 
-Do not submit an AI-generated PR you haven't **personally understood, tested and reviewed**, as this wastes maintainers' time.<br/>
-Undisclosed use of AI or Large Language Models, or inability to explain AI-generated contributions, will lead to your PR being **closed without further review**.
+If you do use LLMs as part of your workflow, you must explicitly disclose it.
+Do not submit a PR you haven't personally tested; inability to explain your code is grounds for immediate rejection of the PR. 
+Understanding the issue and any problem solving must be done by yourself, not by an LLM.
 
-If you use LLMs as part of your workflow (with explicit disclosure), **understanding the issue** and any **problem solving** should be done **by you**.
-
-This is the core of our work as developers. The job market and financially motivated projects may disagree, but this wonderful little open-source bubble has a humanistic philosophy, and prioritizes **community**, **critical thinking** and **robust and long-lasting code** over productivity and speed.
+This is the core of our work as developers. Open-source prioritizes community, critical thinking and robust and long-lasting code over productivity and speed.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ you want to know more about the development process. More info about interesting
 ways we communicate with each other is available at https://wiki.musicbrainz.org/Communication.
 
 ## AI use policy
-We discourage blindly using AI tools in communications or code contributions.
+We don't allow blindly using AI tools in code contributions or communications, and discourage it in most cases.
 
 If you do use LLMs as part of your workflow, you must explicitly disclose it.
 Do not submit a PR you haven't personally tested; inability to explain your code is grounds for immediate rejection of the PR. 
-Understanding the issue and any problem solving must be done by yourself, not by an LLM.
+We want to see *you* (not an LLM) show understanding of the issue and do all the problem solving.
 
 This is the core of our work as developers. Open-source prioritizes community, critical thinking and robust and long-lasting code over productivity and speed.


### PR DESCRIPTION
Following [discussion in our weekly meeting](https://chatlogs.metabrainz.org/libera/metabrainz/2025-12-01/?msg=5528307&page=2), adding a proposal for an AI use policy.

We might want to copy these guidelines in CONTRIBUTING.md and PR templates in each project as well because I expect that contributors opening AI-slop PRs are not going to be reading the guidelines carefully...